### PR TITLE
Added TCP port definition to constructor

### DIFF
--- a/firmware/ParticleFtpClient.cpp
+++ b/firmware/ParticleFtpClient.cpp
@@ -16,13 +16,13 @@ namespace particleftpclient {
 
   #define expect(code)            if (code / 100 != parse_response() / 100) return false;
 
-  bool ParticleFtpClient::open(String hostname, int timeout) {
+  bool ParticleFtpClient::open(String hostname, uint16_t port, int timeout) {
       maxTries = timeout;
   #ifdef PARTICLE_FTP_DEBUG
-      Serial.begin(9600);
+  //    Serial.begin(9600);
   #endif
       d_println("Connecting...");
-      server_cmd_connection.connect(hostname, 21);
+      server_cmd_connection.connect(hostname, port);
       if (!server_cmd_connection.connected()) {
           d_println("Failed to connect to command port");
           return false;

--- a/firmware/ParticleFtpClient.h
+++ b/firmware/ParticleFtpClient.h
@@ -3,7 +3,7 @@
 
 #include "application.h"
 #include <time.h>
-#define PARTICLE_FTP_DEBUG
+//#define PARTICLE_FTP_DEBUG
 #define RESPONSE_BUFFER_SIZE 270
 
 namespace particleftpclient {

--- a/firmware/ParticleFtpClient.h
+++ b/firmware/ParticleFtpClient.h
@@ -3,7 +3,7 @@
 
 #include "application.h"
 #include <time.h>
-
+#define PARTICLE_FTP_DEBUG
 #define RESPONSE_BUFFER_SIZE 270
 
 namespace particleftpclient {
@@ -12,7 +12,7 @@ namespace particleftpclient {
           // Open a conncetion to hostname. Timeout is a global timeout that will
           // be the number of seconds the client will wait for any
           // command to complete.
-          bool open(String hostname, int timeout);
+          bool open(String hostname, uint16_t port, int timeout);
 
           // Sends a username, returns true if the username was accepted
           bool user(String username);

--- a/firmware/examples/ftp.ino
+++ b/firmware/examples/ftp.ino
@@ -7,6 +7,7 @@ using namespace particleftpclient;
 String hostname = "hostname";
 String username = "username";
 String password = "password";
+int port = 21;
 
 int timeout = 5;
 
@@ -28,7 +29,7 @@ void setup() {
     Serial.println("Hello world");
 
     // Connect to host and authenticate, or halt
-    if (!ftp.open(hostname, timeout)) {
+    if (!ftp.open(hostname, port, timeout)) {
       Serial.println("Couldn't connect to ftp host");
       while (1);
     }


### PR DESCRIPTION
I used your library in one of my projects, but added the ability to define a TCP port to the constructor. Maybe this is useful for other people as well. I also removed the Serial initializer when using the DEBUG define. As this is something the developer should define in the system part of the project instead of in a library.